### PR TITLE
[Build image] Build image fail for dependency error with sonic-host-services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject',
+        'PyGObject==3.50.0',
         'pycairo==1.26.1',
         'psutil'
     ] + sonic_dependencies,


### PR DESCRIPTION
Why I did it
Build code error beacuse using new version of PyGObject

How I did it
Fixed specified version of PyGObject in 3.50.0

How to verify it
Build image success