### PR TITLE
[Build image] Build image fail for dependency error with sonic-host-services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject',
+        'PyGObject==3.50.0',
     ] + sonic_dependencies,
     setup_requires = [
         'pytest-runner',


### PR DESCRIPTION
Why I did it
Build code error beacuse using new version of PyGObject

How I did it
Fixed specified version of PyGObject in 3.50.0 (sync pr #1)