### PR TITLE
Add iptables commands to allow mgmt interface from localhost

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -606,6 +606,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Add iptables/ip6tables commands to allow all traffic from localhost
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-s', '127.0.0.1', '-i', 'lo', '-j', 'ACCEPT'])
         iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['ip6tables', '-A', 'INPUT', '-s', '::1', '-i', 'lo', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-s', '127.0.0.1', '-i', 'mgmt', '-j', 'ACCEPT'])
 
         # Add iptables commands to allow internal docker traffic
         iptables_cmds += self.generate_allow_internal_docker_ip_traffic_commands(namespace)


### PR DESCRIPTION
#### Why I did it
When mgmtvrf is enabled. It requires communicate with the ntp daemon through an internal socket, and the acl rule will block that internal communication.
Add iptables commands to allow mgmt interface from localhost

#### How I did it
N/A

#### How to verify it
N/A