### PR TITLE
[caclmgrd]  Add ICCPD TCP port 8888 to the default iptables whitelist

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -668,6 +668,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         #
         iptables_cmds += self.generate_hook_iptables_commands()
 
+        # Add iptables commands to allow all incoming MCLAG traffic (tcp dport/sport 8888)
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'tcp', '--dport', '8888', '-j', 'ACCEPT'])
+        iptables_cmds.append(self.iptables_cmd_ns_prefix[namespace] + ['iptables', '-A', 'INPUT', '-p', 'tcp', '--sport', '8888', '-j', 'ACCEPT'])
+
         # Get current ACL tables and rules from Config DB
 
         self._tables_db_info = config_db_connector.get_table(self.ACL_TABLE)


### PR DESCRIPTION
 Add ICCPD TCP port 8888 to the default iptables whitelist to support MCLAG messages exchange