### PR TITLE
caclmgrd daemon crashed when removing an ACL table.

### DIFF
--- a/scripts/caclmgrd
+++ b/scripts/caclmgrd
@@ -1179,12 +1179,12 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                     # Check ACL Rule notification and make sure Rule point to ACL Table which is Controlplane
                     else:
                         acl_table = key.split(acl_rule_table_separator)[0]
-                        is_acl_table = self.config_db_map[namespace].get_table(self.ACL_TABLE).get(acl_table)
-                        if not is_acl_table:
+                        acl_table_data = self.config_db_map[namespace].get_table(self.ACL_TABLE).get(acl_table)
+                        if not acl_table_data:
                             self.log_warning("Ignoring for non-existent ACL table '{}'".format(acl_table))
                             continue
 
-                        if self.config_db_map[namespace].get_table(self.ACL_TABLE)[acl_table]["type"] == self.ACL_TABLE_TYPE_CTRLPLANE:
+                        if acl_table_data.get("type") == self.ACL_TABLE_TYPE_CTRLPLANE:
                             ctrl_plane_acl_notification.add(namespace)
 
             # Update the Control Plane ACL of the namespace that got config db acl table event


### PR DESCRIPTION
- What I did:
Reduced redundant queries to ConfigDB.

The existing code already handles ACL table deletions, but it still performs an additional ConfigDB query after validation, leading to errors when the ACL table is no longer present.

This update ensures that ConfigDB is queried only once, and the result is used for subsequent processing, preventing errors caused by redundant queries.

- Why I did it: 
Fixed a coding error to prevent crashes due to timing discrepancies in ConfigDB updates.

When caclmgrd processes CLI operations for ACLs, it receives the following three notifications:
  Notification 1: Add ACL table
  Notification 2: Add ACL rule
  Notification 3: Delete ACL table
The issue occurs between the second and third notifications. If the UI deletes the ACL table from ConfigDB before caclmgrd finishes adding the rule, the process may crash when verifying whether the rule's ACL table type is CTRLPLANE, due to improper handling of the missing table case.

- How I verified it:
Repeatedly add an ACL table, insert an ACL rule, and delete the ACL table 100
times without generating any error logs.
```
sudo config acl add table L3_TABLE L3 -p Ethernet0
sudo config acl add rule L3_TABLE permit --src-ip4 [10.0.0.1](http://10.0.0.1/)
sudo config acl remove table L3_TABLE
```