### PR TITLE
[procdockerstatsd] Set TimeoutStopSec for procdockerstatsd.service to 10s.

### DIFF
--- a/data/debian/sonic-host-services-data.procdockerstatsd.service
+++ b/data/debian/sonic-host-services-data.procdockerstatsd.service
@@ -9,6 +9,7 @@ After=sonic.target
 Type=simple
 ExecStart=/usr/local/bin/procdockerstatsd
 Restart=always
+TimeoutStopSec=10s
 
 [Install]
 WantedBy=sonic.target


### PR DESCRIPTION
Based on the logs, the procdockerstatsd.service took 90.01 seconds to stop, which exceeded the DefaultTimeoutStopSec of 90 seconds. This timeout caused systemd to forcefully terminate the service with SIGKILL, leading to the overall fast-reboot process exceeding 300 seconds.

Mar  9 13:01:18.607947 as9726-32d-1 INFO systemd[1]: Stopping Process and docker CPU/memory utilization data export daemon...
Mar  9 13:02:48.616281 as9726-32d-1 WARNING systemd[1]: procdockerstatsd.service: State 'stop-sigterm' timed out. Killing.
Mar  9 13:02:48.616548 as9726-32d-1 NOTICE systemd[1]: procdockerstatsd.service: Killing process 1356 (procdockerstats) with signal SIGKILL.
Mar  9 13:02:48.618670 as9726-32d-1 WARNING systemd[1]: procdockerstatsd.service: Main process exited, code=killed, status=9/KILL
Mar  9 13:02:48.618908 as9726-32d-1 WARNING systemd[1]: procdockerstatsd.service: Failed with result 'timeout'.
Mar  9 13:02:48.620465 as9726-32d-1 INFO systemd[1]: Stopped Process and docker CPU/memory utilization data export daemon.

This change sets the TimeoutStopSec for the procdockerstatsd service to 10s (default 90s). Given the procdockerstatsd daemon's 5-second database update interval, this setting ensures faster termination on shutdown issues, thereby improving system responsiveness.