### PR TITLE
[Build image] Build image fail for dependency error with sonic-host-services

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'dbus-python',
         'systemd-python',
         'Jinja2>=2.10',
-        'PyGObject',
+        'PyGObject==3.50.0',
     ] + sonic_dependencies,
     setup_requires = [
         'pytest-runner',


### PR DESCRIPTION
The dependency of sonic-host-services will use pygobject 3.52.1 which will cause error, change the version to 3.50.0 for original passed version